### PR TITLE
fix: add array type to align with changes in Toolkit\Iterator

### DIFF
--- a/lib/ProvidersManager.php
+++ b/lib/ProvidersManager.php
@@ -7,7 +7,7 @@ use Kirby\Toolkit\Collection;
 class ProvidersManager extends Collection
 {
     private $kirby = null;
-    public $data = [];
+    public array $data = [];
 
     public function __construct(\Kirby\Cms\App $kirby)
     {


### PR DESCRIPTION
In https://github.com/getkirby/kirby/commit/9a2f78b2191fddddb852189ae13d371a301316a0, a couple of changes were made to the `Kirby\Toolkit\Iterator` class, including adding the `array` type to the `$data` prop.
The change was published with Kirby v3.9.0. This PR aligns with the change as otherwise, the following error is rendered when using Kirby >= 3.9.0:
```
Fatal error: Type of Thathoff\Oauth\ProvidersManager::$data must be array (as in class Kirby\Toolkit\Iterator)
```

Thank you!