### PR TITLE
Added plugin hooks before and after the kirby user gets logged in

### DIFF
--- a/README.md
+++ b/README.md
@@ -122,3 +122,18 @@ By default only whitelisted users are allowed to login into the Kirby panel.
 **Default Role:** Newly created users get the role defined with `defaultRole` when they first login. The default is `admin`. Please note that when the user has ben created already the role will not be updated. You can set this role to `nobody` if you want to manually whitelist users by changing the role in the Kirby panel.
 
 **Only Existing User:** By setting `onlyExistingUsers` to true only created uses are able to login with an OAuth provider, no new users are created.
+
+### Use Hooks
+
+Before and after the Kirbyuser gets logged in a hook is triggered. They contain information about the Kirbyuser and the oauthUserData from the authentication request.
+
+```
+'hooks' => [
+    'thathoff.oauth.login:before' => function ($user, $oauthUserData) {
+        
+    },
+    'thathoff.oauth.login:after' => function ($user, $oauthUserData) {
+        
+    }
+]
+```

--- a/README.md
+++ b/README.md
@@ -125,15 +125,27 @@ By default only whitelisted users are allowed to login into the Kirby panel.
 
 ### Use Hooks
 
-Before and after the Kirbyuser gets logged in a hook is triggered. They contain information about the Kirbyuser and the oauthUserData from the authentication request.
+Before and after the KirbyUser gets created or logged in a hook is triggered.
 
 ```
+/**
+ * @var \League\OAuth2\Client\Provider\ResourceOwnerInterface $oauthUser
+ * @var Kirby\Cms\User $user
+ */
+
 'hooks' => [
-    'thathoff.oauth.login:before' => function ($user, $oauthUserData) {
-        
+    'thathoff.oauth.user-create:before' => function ($oauthUser) {
+      // return null|true to use the plugins user-creation
+      // return a Kirby\Cms\User to overwrite the plugin user creation
     },
-    'thathoff.oauth.login:after' => function ($user, $oauthUserData) {
-        
+    'thathoff.oauth.user-create:after' => function ($oauthUser, $user) {
+
+    },
+    'thathoff.oauth.login:before' => function ($oauthUser, $user) {
+
+    },
+    'thathoff.oauth.login:after' => function ($oauthUser, $user) {
+
     }
 ]
 ```

--- a/lib/Controller.php
+++ b/lib/Controller.php
@@ -2,6 +2,7 @@
 
 namespace Thathoff\Oauth;
 
+use Kirby\Cms\User;
 use Kirby\Http\Header;
 use Kirby\Http\Uri;
 use League\OAuth2\Client\Provider\ResourceOwnerInterface;
@@ -146,28 +147,45 @@ class Controller
         }
 
         if (!$kirbyUser = $this->kirby->user($email)) {
-            $onlyExistingUsers = $this->kirby->option('thathoff.oauth.onlyExistingUsers', false);
 
-            if ($onlyExistingUsers) {
-                $this->error("User missing and creating users is disabled!");
+            $createResult = $this->kirby->apply('thathoff.oauth.user-create:before', ['oauthUser' => $oauthUser, 'result' => null], 'result');
+            $kirbyUser = null;
+
+            if ($createResult instanceof User) {
+                $kirbyUser = $createResult;
             }
 
-            if (!$this->checkWhiteLists($email)) {
-                $this->error("Access denied for $email.");
+            if ($createResult === true || $createResult === null) {
+
+                $onlyExistingUsers = $this->kirby->option('thathoff.oauth.onlyExistingUsers', false);
+
+                if ($onlyExistingUsers) {
+                    $this->error("User missing and creating users is disabled!");
+                }
+
+                if (!$this->checkWhiteLists($email)) {
+                    $this->error("Access denied for $email.");
+                }
+
+                $this->kirby->impersonate('kirby');
+                $kirbyUser = $this->kirby->users()->create([
+                    'name'      => $name,
+                    'password'  => bin2hex(random_bytes(32)),
+                    'email'     => $email,
+                    'role'      => $this->kirby->option('thathoff.oauth.defaultRole', 'admin'),
+                ]);
             }
 
-            $this->kirby->impersonate('kirby');
-            $kirbyUser = $this->kirby->users()->create([
-                'name'      => $name,
-                'password'  => bin2hex(random_bytes(32)),
-                'email'     => $email,
-                'role'      => $this->kirby->option('thathoff.oauth.defaultRole', 'admin'),
-            ]);
+            $this->kirby->trigger('thathoff.oauth.user-create:after', ['oauthUser' => $oauthUser, 'user' => $kirbyUser]);
+
+            if(!$kirbyUser) {
+                $this->error("User cannot be created.");
+            }
         }
 
-        $this->kirby->trigger('thathoff.oauth.login:before', ['oauthUserData' => $oauthUserData, 'user' => $kirbyUser]);
+        $this->kirby->trigger('thathoff.oauth.login:before', ['oauthUser' => $oauthUser, 'user' => $kirbyUser]);
         $kirbyUser->loginPasswordless();
-        $this->kirby->trigger('thathoff.oauth.login:after', ['oauthUserData' => $oauthUserData, 'user' => $kirbyUser,]);
+        $this->kirby->trigger('thathoff.oauth.login:after', ['oauthUser' => $oauthUser, 'user' => $kirbyUser,]);
 
         $this->goToPanel();
     }

--- a/lib/Controller.php
+++ b/lib/Controller.php
@@ -165,7 +165,9 @@ class Controller
             ]);
         }
 
+        $this->kirby->trigger('thathoff.oauth.login:before', ['user' => $kirbyUser, 'oauthUserData' => $oauthUserData]);
         $kirbyUser->loginPasswordless();
+        $this->kirby->trigger('thathoff.oauth.login:after', ['user' => $kirbyUser, 'oauthUserData' => $oauthUserData]);
         $this->goToPanel();
     }
 

--- a/lib/Controller.php
+++ b/lib/Controller.php
@@ -165,9 +165,10 @@ class Controller
             ]);
         }
 
-        $this->kirby->trigger('thathoff.oauth.login:before', ['user' => $kirbyUser, 'oauthUserData' => $oauthUserData]);
+        $this->kirby->trigger('thathoff.oauth.login:before', ['oauthUserData' => $oauthUserData, 'user' => $kirbyUser]);
         $kirbyUser->loginPasswordless();
-        $this->kirby->trigger('thathoff.oauth.login:after', ['user' => $kirbyUser, 'oauthUserData' => $oauthUserData]);
+        $this->kirby->trigger('thathoff.oauth.login:after', ['oauthUserData' => $oauthUserData, 'user' => $kirbyUser,]);
+
         $this->goToPanel();
     }
 


### PR DESCRIPTION
Added hooks before and after the kirby user gets logged in.
This was suggested in https://github.com/thathoff/kirby-oauth/issues/30#issuecomment-1432739791

An example use-case is to process the given roles in the oAuthUserData to assign kirby roles.
It would be nice if something like this could be added to the plugin. Feel free to change anything. 