### PR TITLE
Add new adminWhitelist option & use impersonate callback

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,6 +70,11 @@ return [
           // For details see “Configure Allowed Users” below.
         ],
 
+        // List of E-mail addresses which will get the admin role assigned
+        'adminWhitelist' => [
+          // For details see “Configure Allowed Users” below.
+        ],
+
         // Remove the standard Kirby login form and only display OAuth options.
         'onlyOauth' => false,
       ],

--- a/lib/Controller.php
+++ b/lib/Controller.php
@@ -168,12 +168,16 @@ class Controller
                     $this->error("Access denied for $email.");
                 }
 
-                $kirbyUser = $this->kirby->impersonate('kirby', function() use ($name, $email) {
+                $admins = $this->kirby()->option('thathoff.oauth.adminWhitelist');
+                $defaultRole = $this->kirby->option('thathoff.oauth.defaultRole', 'admin');
+                $role = (!empty($admins) && A::has($admins, $email)) ? 'admin' : $defaultRole;
+
+                $kirbyUser = $this->kirby->impersonate('kirby', function() use ($name, $email, $role) {
                     return $this->kirby->users()->create([
                         'name'      => $name,
                         'password'  => bin2hex(random_bytes(32)),
                         'email'     => $email,
-                        'role'      => $this->kirby->option('thathoff.oauth.defaultRole', 'admin'),
+                        'role'      => $role,
                     ]);
                 });
             }

--- a/lib/Controller.php
+++ b/lib/Controller.php
@@ -168,13 +168,14 @@ class Controller
                     $this->error("Access denied for $email.");
                 }
 
-                $this->kirby->impersonate('kirby');
-                $kirbyUser = $this->kirby->users()->create([
-                    'name'      => $name,
-                    'password'  => bin2hex(random_bytes(32)),
-                    'email'     => $email,
-                    'role'      => $this->kirby->option('thathoff.oauth.defaultRole', 'admin'),
-                ]);
+                $kirbyUser = $this->kirby->impersonate('kirby', function() use ($name, $email) {
+                    return $this->kirby->users()->create([
+                        'name'      => $name,
+                        'password'  => bin2hex(random_bytes(32)),
+                        'email'     => $email,
+                        'role'      => $this->kirby->option('thathoff.oauth.defaultRole', 'admin'),
+                    ]);
+                });
             }
 
             $this->kirby->trigger('thathoff.oauth.user-create:after', ['oauthUser' => $oauthUser, 'user' => $kirbyUser]);

--- a/plugin/options.php
+++ b/plugin/options.php
@@ -5,6 +5,7 @@ return [
     'defaultRole' => null,
     'domainWhitelist' => null,
     'emailWhitelist' => null,
+    'adminWhitelist' => null,
     'onlyOauth' => null,
     'onlyExistingUsers' => null,
     'allowEveryone' => null,


### PR DESCRIPTION
Adding a new option `thathoff.oauth.adminWhitelist` to allow whitelisted email addresses to get the admin role assigned on account creation. 

Limiting the impact of the impersonate() method when creating a new user by calling it instead with a callback.