### PR TITLE
 Fix OAuth Controller to use $this->kirby property

### DIFF
--- a/lib/Controller.php
+++ b/lib/Controller.php
@@ -162,7 +162,7 @@ class Controller
 
                 $onlyExistingUsers = $this->kirby->option('thathoff.oauth.onlyExistingUsers', false);
                 $defaultRole = $this->kirby->option('thathoff.oauth.defaultRole', 'admin');
-                $admins = $this->kirby()->option('thathoff.oauth.adminWhitelist');
+                $admins = $this->kirby->option('thathoff.oauth.adminWhitelist');
 
                 if ($onlyExistingUsers) {
                     $this->error("User missing and creating users is disabled!");


### PR DESCRIPTION
**What happened**
The Controller was calling the non-existent method `$this->kirby()` instead of
using the existing `$this->kirby` property, causing a fatal undefined method
error under Kirby 4 & 5.
-> https://github.com/thathoff/kirby-oauth/blob/d2b76daa7f34e5e9dcf4649ea2c0204afaca863c/lib/Controller.php#L165C39-L165C41

**What this PR does**
- Replaces the `$this->kirby()->option(...)` calls with `$this->kirby->option(...)`.
- Ensures OAuth logins work without errors in Kirby 4 and 5.
