### PR TITLE
fix: use array as fallback for admin whitelist

### DIFF
--- a/lib/Controller.php
+++ b/lib/Controller.php
@@ -162,7 +162,7 @@ class Controller
 
                 $onlyExistingUsers = $this->kirby->option('thathoff.oauth.onlyExistingUsers', false);
                 $defaultRole = $this->kirby->option('thathoff.oauth.defaultRole', 'admin');
-                $admins = $this->kirby->option('thathoff.oauth.adminWhitelist');
+                $admins = $this->kirby->option('thathoff.oauth.adminWhitelist', []);
 
                 if ($onlyExistingUsers) {
                     $this->error("User missing and creating users is disabled!");


### PR DESCRIPTION
- defaulted to `null`, which caused an error when trying to login with an email address that had no corresponding user.